### PR TITLE
InternalWaveModel.m suggested changes

### DIFF
--- a/Matlab/InternalWaveModel/InternalWaveModelConstantStratification.m
+++ b/Matlab/InternalWaveModel/InternalWaveModelConstantStratification.m
@@ -49,6 +49,7 @@ classdef InternalWaveModelConstantStratification < InternalWaveModel
         %
         %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
         function self = InternalWaveModelConstantStratification(dims, n, latitude, N0, rho0)    % MAS 1/11/18
+            % rho0 is optional.
             if length(dims) ~=3 || length(n) ~= 3
                 error('The dims and n variables must be of length 3. You need to specify x,y,z');
             end
@@ -72,8 +73,13 @@ classdef InternalWaveModelConstantStratification < InternalWaveModel
             
             self@InternalWaveModel(dims, n, z, N0*N0*ones(size(z)), nModes, latitude);
             
+            if exist('rho0','var')
+                self.rho0 = rho0;
+            else
+                self.rho0 = 1025;
+            end
+            
             self.N0 = N0;
-            %self.rho0 = 1025;
             self.nz = nz;
             
             rhoFunction = @(z) -(self.N0*self.N0*self.rho0/9.81)*z + self.rho0;

--- a/Matlab/InternalWaveModel/InternalWaveModelConstantStratification.m
+++ b/Matlab/InternalWaveModel/InternalWaveModelConstantStratification.m
@@ -48,7 +48,7 @@ classdef InternalWaveModelConstantStratification < InternalWaveModel
         % Initialization
         %
         %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-        function self = InternalWaveModelConstantStratification(dims, n, latitude, N0)
+        function self = InternalWaveModelConstantStratification(dims, n, latitude, N0, rho0)    % MAS 1/11/18
             if length(dims) ~=3 || length(n) ~= 3
                 error('The dims and n variables must be of length 3. You need to specify x,y,z');
             end
@@ -73,7 +73,7 @@ classdef InternalWaveModelConstantStratification < InternalWaveModel
             self@InternalWaveModel(dims, n, z, N0*N0*ones(size(z)), nModes, latitude);
             
             self.N0 = N0;
-            self.rho0 = 1025;
+            %self.rho0 = 1025;
             self.nz = nz;
             
             rhoFunction = @(z) -(self.N0*self.N0*self.rho0/9.81)*z + self.rho0;

--- a/Matlab/InternalWaveModel/UnitTests/CheckAllPlaneWaveSolutions.m
+++ b/Matlab/InternalWaveModel/UnitTests/CheckAllPlaneWaveSolutions.m
@@ -28,8 +28,8 @@ Nz = 4;
 latitude = [0 31];
 N0 = 5.2e-3/2; % Choose your stratification 7.6001e-04
 U = 0.01; % m/s
-phi = 0*0.232; % random, just to see if its doing the right thing
-t = 4*86400;
+phi = 0*0.232; % random, just to see if its doing the right thing API = 1 will fail, because you can't set the phase using that API.
+t = 2.13*86400;
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
@@ -65,8 +65,8 @@ for iLat = 1:length(latitude)
     for k_loop=(-Nx/2 + 1):1:(Nx/2-1)
         for l_loop=(-Ny/2 + 1):1:(Ny/2-1)
             fprintf('(k0,l0)=(%d,%d) ',k_loop,l_loop);
-            for j0=1:Nz/2
-                for sign=-1:2:1
+            for j0=1:(Nz-1)
+                for thesign=-1:2:1
                     
                     %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
                     %
@@ -90,7 +90,7 @@ for iLat = 1:length(latitude)
                     ll = l(l0+1);
                     alpha=atan2(ll,kk);
                     K = sqrt( kk^2 + ll^2);
-                    omega = sign*sqrt( (K*K*N0*N0 + m*m*f0*f0)/(K*K+m*m) );
+                    omega = thesign*sqrt( (K*K*N0*N0 + m*m*f0*f0)/(K*K+m*m) );
                     
                     if latitude(iLat) == 0
                         f0OverOmega = 0;
@@ -109,7 +109,8 @@ for iLat = 1:length(latitude)
                     v_unit = U*(sin(alpha)*cos( theta ) - f0OverOmega*cos(alpha)*sin( theta )).*cos(m*Z);
                     w_unit = (U*K/m) * sin( theta ) .* sin(m*Z);
                     zeta_unit = -(U/m) * kOverOmega * cos( theta ) .* sin(m*Z);
-                    rho_unit = rho0 -(N0*N0*rho0/g)*reshape(wavemodel.z,1,1,[]) -(rho0/g)*N0*N0*(U*K/m/omega) * cos( theta ) .* sin(m*Z);
+                    rho_prime_unit = -(rho0/g)*N0*N0*(U*K/m/omega) * cos( theta ) .* sin(m*Z);
+                    rho_unit = rho0 -(N0*N0*rho0/g)*reshape(wavemodel.z,1,1,[]) + rho_prime_unit;
                     
                     if any(any(any(isnan(zeta_unit))))
                         error('nan')
@@ -128,19 +129,25 @@ for iLat = 1:length(latitude)
                         
                         if API == 1
                             apiName = 'InitializeWithPlaneWave';
-                            wavemodel.InitializeWithPlaneWave(k_loop,l_loop,j0,U,sign);
+                            wavemodel.InitializeWithPlaneWave(k_loop,l_loop,j0,U,thesign);         
                         elseif API == 2
                             apiName = 'SetGriddedWavesWithWavemodes';
-                            wavemodel.SetGriddedWavesWithWavemodes(k_loop,l_loop,j0,phi,U,sign);
+                            wavemodel.SetGriddedWavesWithWavemodes(k_loop,l_loop,j0,phi,U,thesign);
+                            [omega_p, alpha_p, k_p, l_p, j_p, phi_p, A_p,norm] = wavemodel.WaveCoefficientsFromGriddedWaves();
                         elseif API == 3
                             apiName = 'SetExternalWavesWithWavenumbers';
-                            wavemodel.SetExternalWavesWithWavenumbers(sign*kk, sign*ll, j0, sign*phi,sign*U,Normalization.uMax);
+                            if omega_p == 0
+                                signchange = 1;
+                            else
+                                signchange = sign(omega_p);
+                            end
+                            wavemodel.SetExternalWavesWithWavenumbers(signchange*k_p, signchange*l_p, j_p, signchange*phi_p,signchange*A_p,norm);
                         elseif API == 4
                             apiName = 'SetExternalWavesWithFrequencies';
-                            wavemodel.SetExternalWavesWithFrequencies(omega, alpha, j0, phi,U,Normalization.uMax);
+                            wavemodel.SetExternalWavesWithFrequencies(omega_p, alpha_p, j_p, phi_p,A_p,norm);
                         end
                         
-                        [u,v,w,zeta] = wavemodel.VariableFieldsAtTime(t,'u','v','w','zeta');
+                        [u,v,w,zeta,rho_prime] = wavemodel.VariableFieldsAtTime(t,'u','v','w','zeta','rho_prime');
                         rho = wavemodel.DensityFieldAtTime(t);
                         
                         % Compute the relative error
@@ -153,21 +160,21 @@ for iLat = 1:length(latitude)
                         w_error = max( [max(max(max(abs(w-w_unit)/max_w))), 1e-15] );
                         max_zeta = max( [max(max(max( zeta ))), 1e-15] );
                         zeta_error = max( [max(max(max(abs(zeta-zeta_unit)/max_zeta))), 1e-15] );
-                        max_rho = max( [max(max(max( rho ))), 1e-15] );
-                        rho_error = max( [max(max(max(abs(rho-rho_unit)/max_rho))), 1e-15] );
+                        max_rho = max( [max(max(max( rho_prime ))), 1e-15] );
+                        rho_error = max( [max(max(max(abs(rho_prime-rho_prime_unit)/max_rho))), 1e-15] );
                         
                         max_error = max([round((log10(u_error)))  round((log10(v_error))) round((log10(w_error))) round((log10(zeta_error))) round((log10(rho_error)))],[],'includenan');
                         
                         totalTests = totalTests + 1;
                         if isnan(max_error) || max_error > -3
                             totalErrors = totalErrors + 1;
-                            if sign > 0
+                            if thesign > 0
                                 fprintf('\nFound at large error at lat=%f with %s at +(k,l,j)=(%d,%d,%d):\n', latitude(iLat),apiName,k_loop,l_loop,j0);
                             else
                                 fprintf('\nFound at large error at lat=%f  with %s at -(k,l,j)=(%d,%d,%d):\n', latitude(iLat),apiName,k_loop,l_loop,j0);
                             end
                             fprintf('The model solution for (u,v) matches the analytical solution to 1 part in (10^%d, 10^%d) at time t=%d\n', round((log10(u_error))), round((log10(v_error))),t);
-                            fprintf('The model solution for (w,zeta,rho) matches the analytical solution to 1 part in (10^%d, 10^%d, 10^%d) at time t=%d\n', round((log10(w_error))), round((log10(zeta_error))), round((log10(rho_error))),t);
+                            fprintf('The model solution for (w,zeta,rho_prime) matches the analytical solution to 1 part in (10^%d, 10^%d, 10^%d) at time t=%d\n', round((log10(w_error))), round((log10(zeta_error))), round((log10(rho_error))),t);
                         end
                     end % API loop
                 end % sign loop

--- a/Matlab/InternalWaveModel/UnitTests/InternalExternalGMSpectrumUnitTest.m
+++ b/Matlab/InternalWaveModel/UnitTests/InternalExternalGMSpectrumUnitTest.m
@@ -45,7 +45,7 @@ wavemodel.InitializeWithGMSpectrum(1.0)
 % [u_gridded,v_gridded] = wavemodel.VelocityFieldAtTime(t);
 [u_gridded,v_gridded,w_gridded,rho_prime_gridded] = wavemodel.VariableFieldsAtTime(t,'u','v','w','rho_prime');
 
-[omega, alpha, mode, phi, A] = wavemodel.WaveCoefficientsFromGriddedWaves();
+[omega, alpha, k, l, mode, phi, A] = wavemodel.WaveCoefficientsFromGriddedWaves();
 L_gm = 1.3e3; % thermocline exponential scale, meters
 invT_gm = 5.2e-3; % reference buoyancy frequency, radians/seconds
 E_gm = 6.3e-5; % non-dimensional energy parameter


### PR DESCRIPTION
Not sure if I'm setting up this fork and pull request correctly, but here's a go at it!

Main changes I'm suggesting are in:

- WaveCoefficientsFromGriddedWaves: pass back k,l wavenumbers along with other variables
- PlaceParticlesOnIsopycnal: add input 'intext' to select whether to place based on internal modes or both internal+external; pass rhoIsopycnal as output (goes along with zIsopycnal); some additional book-keeping and plotting
- ShowResolvedWavenumbersPlot: a new code like ShowResolvedModesPlot, but showing in wavenumber space.

in InternalWaveModelConstantStratification.m and InternalModes.m, would like to implement letting rho0 be passed in by user rather than assigned within code to be 1025 kg/m^3.  Spent a while tracking this down as one reason my floats were not lining up with the isopycnal I thought they should be on!